### PR TITLE
Fixed Shapeless Recipe Example

### DIFF
--- a/chapters/nodes_items_crafting.md
+++ b/chapters/nodes_items_crafting.md
@@ -239,9 +239,7 @@ need to be in any specific place for it to work.
 minetest.register_craft({
 	type = "shapeless",
 	output = "mymod:diamond",
-	recipe = {
-		{"mymod:diamond_fragments" "mymod:diamond_fragments", "mymod:diamond_fragments"}
-	}
+	recipe = {"mymod:diamond_fragments" "mymod:diamond_fragments", "mymod:diamond_fragments"}
 })
 {% endhighlight %}
 


### PR DESCRIPTION
Because the shapeless recipe example comprised of three lines (see below), Minetest gives an invalid recipe error as shapeless recipes must comprise of only one line (see my example).

**The original code:**
```
recipe = {
		{"mymod:diamond_fragments" "mymod:diamond_fragments", "mymod:diamond_fragments"}
	}
```

**My update:**
```
recipe = {"mymod:diamond_fragments" "mymod:diamond_fragments", "mymod:diamond_fragments"}
```

This prevents Minetest from giving an invalid recipe error.