### PR TITLE
Fix typo in chapters/itemstacks.md

### DIFF
--- a/chapters/itemstacks.md
+++ b/chapters/itemstacks.md
@@ -94,8 +94,8 @@ print("Took " .. taken:get_count() .. " items")
 
 ## Wear
 
-ItemStacks also have wear on them. Wear is a number out of 65535, the higher is
-more warn.
+ItemStacks also have wear on them. Wear is a number out of 65535, the higher it is,
+the more wear.
 
 You use `add_wear()`, `get_wear()` and `set_wear(wear)`.
 


### PR DESCRIPTION
The changed sentence read "ItemStacks also have wear on them. Wear is a number out of 65535, the higher is more warn.", I changed it too "ItemStacks also have wear on them. Wear is a number out of 65535, the higher it is, the more wear.".