### PR TITLE
Correct typo missing a comma

### DIFF
--- a/chapters/nodes_items_crafting.md
+++ b/chapters/nodes_items_crafting.md
@@ -239,7 +239,7 @@ need to be in any specific place for it to work.
 minetest.register_craft({
 	type = "shapeless",
 	output = "mymod:diamond",
-	recipe = {"mymod:diamond_fragments" "mymod:diamond_fragments", "mymod:diamond_fragments"}
+	recipe = {"mymod:diamond_fragments", "mymod:diamond_fragments", "mymod:diamond_fragments"}
 })
 {% endhighlight %}
 


### PR DESCRIPTION
add "," between items