### PR TITLE
Fix wiki link (../releasing.md)

### DIFF
--- a/_en/quality/releasing.md
+++ b/_en/quality/releasing.md
@@ -197,7 +197,7 @@ mod named superspecial:
         the folder in worldmods/ in your world directory.  )
 
     For further information or help see:
-    [url]http://wiki.minetest.com/wiki/Installing_Mods[/url]
+    [url]https://wiki.minetest.net/Installing_Mods[/url]
 
 If you modify the above example for your mod topic, remember to
 change "superspecial" to the name of your mod.


### PR DESCRIPTION
I recently noticed that the wiki link was wrong on "Releasing a mod" section.
AFAIK, the original wiki is with ".net", not with ".com" (Also, the wiki link on "minetest.net" is not with ".com").
If this PR is incorrect, please close it.
_P.S: Nice modding book!_